### PR TITLE
switch to using waiter_hide_on_render

### DIFF
--- a/app.R
+++ b/app.R
@@ -18,6 +18,7 @@ library(waiter)
 ui <- fluidPage(
   
   waiter::use_waiter(),
+  waiter_hide_on_render("betaPlot_lower"),
 
   # Application title
   titlePanel("Statistics 101 - Probability distributions"),
@@ -1115,7 +1116,6 @@ server <- function(input, output) {
   
   waiter <- waiter::Waiter$new()
   waiter$show()
-  on.exit(waiter$hide())
   
   output$results_distribution <- renderUI({
     if (input$distribution == "Beta") {


### PR DESCRIPTION
Hi Antoine,

I just made a minor change, using `waiter_hide_on_render("betaPlot_lower")` makes the loading screen go away when the plot (`betaPlot_lower`) is rendered on screen.

This makes it work better as when the loading screen disappears the page is properly populated.