### PR TITLE
Configure automated test runs for PRs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,31 @@
+name: R Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install dependencies
+        run: |
+          install.packages(c(
+            "shiny", "shinycssloaders", "shinythemes",
+            "dplyr", "ggplot2", "mixdist", "testthat"
+          ))
+        shell: Rscript {0}
+
+      - name: Run tests
+        run: Rscript tests/testthat.R


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/run-tests.yml` to automatically run the `testthat` test suite on every push and pull request targeting `master`
- Uses `r-lib/actions/setup-r@v2` with RSPM binary packages for fast installation on Linux
- Installs all app dependencies (`shiny`, `shinycssloaders`, `shinythemes`, `dplyr`, `ggplot2`, `mixdist`) plus `testthat`, then runs `Rscript tests/testthat.R`

Closes #16

## Test plan

- [x] Verify the workflow appears in the Actions tab after merge
- [x] Confirm a subsequent PR triggers the workflow and tests pass